### PR TITLE
feat: use ENV to configure working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,24 @@ ddev pnpm
 ```
 
 Please refer to the documentation at [pnpm.io](https://pnpm.io)
+
+### Working directory
+
+By default, this add-on assumes your `package.json` is in the root of the DDEV project.
+
+In a monorepo, such as the one below, `package.json` is in `frontend`.
+
+```md
+.
+├── .ddev
+├── backend/
+│   └── composer.json
+└── frontend/
+    └── package.json
+```
+
+To configure this addon to run PNPM commands for this example project, set a `PNPM_DIRECTORY` environment variable to `frontend`. For example: `.ddev/.env`
+
+```env
+PNPM_DIRECTORY=frontend
+```

--- a/commands/web/pnpm
+++ b/commands/web/pnpm
@@ -7,4 +7,9 @@
 ## ExecRaw: true
 ## HostWorkingDir: true
 
-pnpm "$@"
+# If a $PNPM_DIRECTORY is set, run our PNPM commands in that directory
+if [ -n "$PNPM_DIRECTORY" ]; then
+  pnpm --dir "$PNPM_DIRECTORY" "$@"
+else
+  pnpm "$@"
+fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,6 +1,6 @@
 setup() {
   set -eu -o pipefail
-  
+
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
   export TESTDIR=~/tmp/ddev-pnpm
   mkdir -p $TESTDIR
@@ -39,4 +39,23 @@ teardown() {
   ddev get envsa/ddev-pnpm
   ddev restart
   health_checks
+}
+
+@test "use ENV to set working directory" {
+  set -eu -o pipefail
+  cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
+  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev get ${DIR}
+
+  # Create a frontend prject
+  cp ${DIR}/tests/testdata/frontend ${TESTDIR}/frontend -r
+
+  # Set the PNPM_DIRECTORY to match our frontend project
+  echo PNPM_DIRECTORY=frontend > ./.ddev/.env
+
+  # Restart DDEV to apply the .env settings
+  ddev restart
+
+  # Confirm it can run the script
+  ddev pnpm test | grep 'directory=frontend'
 }

--- a/tests/testdata/frontend/package.json
+++ b/tests/testdata/frontend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo directory=$PNPM_DIRECTORY"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.5.2"
+}


### PR DESCRIPTION
This PR adds the ability to set a working directory for mono-repositories.

By setting an `PNPM_DIRECTORY` environmental variable, PNPM will automatic set a working directory.

This PR simply checks if the ENV exists and uses it.
A developer may still override this value on the command line if required.

A test is included to prevent regression.