### PR TITLE
bump "github-action-add-on-test"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: ddev/github-action-add-on-test@v1
+      - uses: ddev/github-action-add-on-test@v2
         with:
           ddev_version: ${{ matrix.ddev_version }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## The Issue

The official workflow uses the keep-alive action. This generates commit after inactivity to prevent automated testing from being disabled.

## How This PR Solves The Issue
This PR updates the workflow to a version that does not generate commits.

## Related Issue Link(s)

https://github.com/gautamkrishnar/keepalive-workflow/releases/tag/2.0.0