### PR TITLE
Add pnpm home location to the path

### DIFF
--- a/homeadditions/.bashrc.d/pnpm.sh
+++ b/homeadditions/.bashrc.d/pnpm.sh
@@ -1,0 +1,8 @@
+#ddev-generated
+
+# Add pnpm home location to the path.
+export PNPM_HOME="$HOME/.local/share/pnpm"
+case ":$PATH:" in
+  *":$PNPM_HOME:"*) ;;
+  *) export PATH="$PNPM_HOME:$PATH" ;;
+esac


### PR DESCRIPTION
The `pnpm link` command shows an error:
``` ERR_PNPM_NO_GLOBAL_BIN_DIR  Unable to find the global bin directory
```
This is because we do not add the pnpm home directory to the path. 

This PR fixes the issue.