### PR TITLE
chore(*): prepare for official release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,43 +2,44 @@ name: 🐞 Bug report or Support Request
 description: Create a report to help us improve.
 labels: [bug]
 body:
-    - type: checkboxes
-      attributes:
-        label: Preliminary checklist
-        description: Please complete the following checks before submitting an issue.
-        options:
-            - label: I am using the latest stable version of DDEV
-              required: true
-            - label: I am using the latest stable version of the envsa/ddev-pnpm add-on
-    - type: textarea
-      attributes:
-        label: Expected Behavior
-        description: What did you expect to happen?
-      validation:
-        required: true
-    - type: textarea
-      attributes:
-        label: Actual Behavior
-        description: What actually happened instead?
-      validation:
-        required: true
-    - type: textarea
-      attributes:
-        label: Steps To Reproduce
-        description: Specific steps to reproduce the behavior.
-        placeholder: |
-            1. In this environment...
-            2. With this config...
-            3. Run `...`
-            4. See error...
-      validation:
-        required: false
-    - type: textarea
-      attributes:
-        label: Anything else?
-        description: |
-            Links? References? Screenshots? Anything that will give us more context about your issue!
+  - type: checkboxes
+    attributes:
+      label: Preliminary checklist
+      description: Please complete the following checks before submitting an issue.
+      options:
+        - label: I am using the latest stable version of DDEV
+          required: true
+        - label: I am using the latest stable version of this add-on
+          required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Actual Behavior
+      description: What actually happened instead?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Specific steps to reproduce the behavior.
+      placeholder: |
+        1. In this environment...
+        2. With this config...
+        3. Run `...`
+        4. See error...
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Screenshots? Anything that will give us more context about your issue!
 
-            💡 Attach images or log files by clicking this area to highlight it and dragging files in.
-      validation:
-        required: false
+        💡 Attach images or log files by clicking this area to highlight it and dragging files in.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,14 +6,14 @@
 
 ## How This PR Solves The Issue
 
-<!-- Describe the key change(s) in this PR that addresses the issue above. -->
+<!-- Describe the key change(s) in this PR that address the issue above. -->
 
 ## Manual Testing Instructions
 
 <!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->
 
 ```bash
-ddev add-on get https://github.com/envsa/ddev-pnpm/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
+ddev add-on get https://github.com/ddev/ddev-pnpm/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
 ddev restart
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,27 @@
 [![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
-[![tests](https://github.com/envsa/ddev-pnpm/actions/workflows/tests.yml/badge.svg)](https://github.com/envsa/ddev-pnpm/actions/workflows/tests.yml) 
-[![last commit](https://img.shields.io/github/last-commit/envsa/ddev-pnpm)](https://github.com/envsa/ddev-pnpm/commits)
-[![release](https://img.shields.io/github/v/release/envsa/ddev-pnpm)](https://github.com/envsa/ddev-pnpm/releases/latest)
+[![tests](https://github.com/ddev/ddev-pnpm/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-pnpm/actions/workflows/tests.yml) 
+[![last commit](https://img.shields.io/github/last-commit/ddev/ddev-pnpm)](https://github.com/ddev/ddev-pnpm/commits)
+[![release](https://img.shields.io/github/v/release/ddev/ddev-pnpm)](https://github.com/ddev/ddev-pnpm/releases/latest)
 
-<div align="center">
-    <a href="https://ddev.com/">
-        <img src="https://docs.ddev.com/en/stable/developers/logos/SVG/Logo_w_text.svg" alt="DDEV logo" height="80">
-    </a>
-    <a href="https://pnpm.io">
-        <img src="https://avatars.githubusercontent.com/u/21320719?s=200&v=4" alt="pnpm Logo" height="80">
-    </a>
-    <h1 align="center">ddev-pnpm</h1>
-</div>
+## DDEV pnpm
 
 ## Overview
 
 [pnpm](https://pnpm.io/) is a fast, disk space efficient package manager.
 
-This add-on integrates pnpm into your [DDEV](https://ddev.com/) project.
+This add-on integrates `pnpm` into your [DDEV](https://ddev.com/) project.
 
 ## Installation
+
 ```bash
-ddev add-on get envsa/ddev-pnpm
+ddev add-on get ddev/ddev-pnpm
 ddev restart
 ```
 
+After installation, make sure to commit the `.ddev` directory to version control.
+
 ## Usage
+
 | Command | Description |
 | ------- | ----------- |
 | `ddev pnpm` | Run pnpm from within the web container |
@@ -47,11 +43,14 @@ In a monorepo that doesn't have a root level `package.json`, e.g.
     └── package.json
 ```
 
-To configure this addon to run PNPM commands for this example project, set a `PNPM_DIRECTORY` environment variable to `frontend`. For example: `.ddev/.env`
+To configure this addon to run `pnpm` commands for this example project, set a `PNPM_DIRECTORY` environment variable to `frontend`:
 
-```env
-PNPM_DIRECTORY=frontend
+```bash
+ddev dotenv set .ddev/.env.web --pnpm-directory=frontend
 ```
 
+Make sure to commit the `.ddev/.env.web` file to version control.
+
 ## Credits
+
 **Contributed and maintained by [@rellafella](https://github.com/rellafella)**

--- a/commands/web/pnpm
+++ b/commands/web/pnpm
@@ -2,10 +2,11 @@
 
 #ddev-generated
 ## Description: Run pnpm in the web container
-## Usage: pnpm
+## Usage: pnpm [flags] [args]
 ## Example: "ddev pnpm"
 ## ExecRaw: true
 ## HostWorkingDir: true
+## MutagenSync: true
 
 # If a $PNPM_DIRECTORY is set, run our PNPM commands in that directory
 if [ -n "$PNPM_DIRECTORY" ]; then

--- a/homeadditions/.bashrc.d/pnpm.sh
+++ b/homeadditions/.bashrc.d/pnpm.sh
@@ -1,8 +1,0 @@
-#ddev-generated
-
-# Add pnpm home location to the path.
-export PNPM_HOME="$HOME/.local/share/pnpm"
-case ":$PATH:" in
-  *":$PNPM_HOME:"*) ;;
-  *) export PATH="$PNPM_HOME:$PATH" ;;
-esac

--- a/install.yaml
+++ b/install.yaml
@@ -1,18 +1,7 @@
-# Details about the install.yaml file are at https://ddev.readthedocs.io/en/stable/users/extend/additional-services/#sections-and-features-of-ddev-get-add-on-installyaml
-
 name: ddev-pnpm
-# list of files and directories listed that are copied into project .ddev directory
-# Each file should contain #ddev-generated so it can be replaced by a later `ddev add-on get`
-# if it hasn't been modified by the user.
-# DDEV environment variables can be interpolated into these filenames
-# If you use directories, they must be directories that are managed
-# by this add-on, or removal could remove things that are not owned by it
+
 project_files:
   - commands/web/pnpm
   - web-build/Dockerfile.pnpm
 
-# Version constraint for DDEV that will be validated against the running DDEV executable
-# and prevent add-on from being installed if it doesn't validate.
-# See https://github.com/Masterminds/semver#checking-version-constraints for constraint rules.
-# Available with DDEV v1.23.4+, and works only for DDEV v1.23.4+ binaries
 ddev_version_constraint: '>= v1.24.3'

--- a/web-build/Dockerfile.pnpm
+++ b/web-build/Dockerfile.pnpm
@@ -1,2 +1,12 @@
 #ddev-generated
-RUN npm install --global pnpm
+
+RUN npm install --global pnpm && \
+    PNPM_SCRIPT=$(printf '%s\n' \
+        'export PNPM_HOME="$HOME/.local/share/pnpm"' \
+        'case ":$PATH:" in' \
+        '    *":$PNPM_HOME:"*) ;;' \
+        '    *) PATH="$PNPM_HOME:$PATH" ;;' \
+        'esac' \
+        'export PATH') && \
+    echo "$PNPM_SCRIPT" >> /etc/bash.bashrc && \
+    echo "$PNPM_SCRIPT" >> /etc/bash.nointeractive.bashrc


### PR DESCRIPTION
## The Issue

Preparing for official release.

## How This PR Solves The Issue

- Removes the images from README.md, because they are not displayed correctly at https://addons.ddev.com/addons/envsa/ddev-pnpm
- Updates `envsa/ddev-pnpm` to `ddev/ddev-pnpm`
- Removes not used `homeadditions/.bashrc.d/pnpm.sh`
- Adds the logic from `homeadditions/.bashrc.d/pnpm.sh` to `web-build/Dockerfile.pnpm`
- Refactors tests

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/ddev/ddev-pnpm/tarball/refs/pull/7/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
