### PR TITLE
fix: make pnpm install conditional, fixes #8

### DIFF
--- a/web-build/Dockerfile.pnpm
+++ b/web-build/Dockerfile.pnpm
@@ -1,6 +1,6 @@
 #ddev-generated
 
-RUN npm install --global pnpm && \
+RUN (command -v pnpm >/dev/null 2>&1 || npm install --global pnpm) && \
     PNPM_SCRIPT=$(printf '%s\n' \
         'export PNPM_HOME="$HOME/.local/share/pnpm"' \
         'case ":$PATH:" in' \


### PR DESCRIPTION
## The Issue

- Fixes #8 

PNPM is sometimes already available in the system, for example having corepack enabled.

## How This PR Solves The Issue

Conditionally run the npm --global install command in the dockerfile.
