### PR TITLE
chore: bump version constraint to v1.24.10

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -4,4 +4,4 @@ project_files:
   - commands/web/pnpm
   - web-build/Dockerfile.pnpm
 
-ddev_version_constraint: '>= v1.24.3'
+ddev_version_constraint: '>= v1.24.10'


### PR DESCRIPTION
## The Issue

```bash
$ curl -fsSL https://ddev.com/s/addon-update-checker.sh | bash
ERROR: Actions needed:
- install.yaml should contain `ddev_version_constraint: '>= v1.24.10'` or higher, see upstream file https://github.com/ddev/ddev-addon-template/blob/main/install.yaml
```

## How This PR Solves The Issue

Bumps version constraint to v1.24.10

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-pnpm/tarball/refs/pull/12/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
