### PR TITLE
fix: update $PATH to use $PNPM_HOME/bin, make $PNPM_DIRECTORY relative to $DDEV_APPROOT

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{bats,sh,yml,yaml}]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 tests/ export-ignore
 .github/ export-ignore
 .gitattributes export-ignore
+.editorconfig export-ignore

--- a/commands/web/pnpm
+++ b/commands/web/pnpm
@@ -14,7 +14,11 @@ fi
 
 # If a $PNPM_DIRECTORY is set, run our PNPM commands in that directory
 if [ -n "$PNPM_DIRECTORY" ]; then
-  pnpm --dir "$PNPM_DIRECTORY" "$@"
-else
-  pnpm "$@"
+  mkdir -p "$PNPM_DIRECTORY"
+  cd "$PNPM_DIRECTORY" || {
+    echo "Error: Failed to change directory to '$PNPM_DIRECTORY'." >&2
+    exit 1
+  }
 fi
+
+pnpm "$@"

--- a/commands/web/pnpm
+++ b/commands/web/pnpm
@@ -14,9 +14,9 @@ fi
 
 # If a $PNPM_DIRECTORY is set, run our PNPM commands in that directory
 if [ -n "$PNPM_DIRECTORY" ]; then
-  mkdir -p "$PNPM_DIRECTORY"
-  cd "$PNPM_DIRECTORY" || {
-    echo "Error: Failed to change directory to '$PNPM_DIRECTORY'." >&2
+  mkdir -p "$DDEV_APPROOT/$PNPM_DIRECTORY"
+  cd "$DDEV_APPROOT/$PNPM_DIRECTORY" || {
+    echo "Error: Failed to change directory to '$DDEV_APPROOT/$PNPM_DIRECTORY'." >&2
     exit 1
   }
 fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -58,7 +58,7 @@ health_checks() {
     assert_file_exist package.json
   fi
 
-  run ddev pnpm link
+  run ddev pnpm link .
   assert_success
 }
 
@@ -126,7 +126,7 @@ teardown() {
   # Verify is-odd@3.0.1 is stored in the global cache after installing
   run ddev pnpm install
   assert_success
-  run ddev exec bash -c "grep -r 'is-odd' /mnt/ddev-global-cache/pnpm 2>/dev/null | grep '3.0.1'"
+  run ddev exec bash -c "grep -R 'is-odd' /mnt/ddev-global-cache/pnpm 2>/dev/null | grep '3.0.1'"
   assert_success
 
   # Install the same package version from a second directory and verify it is reused from cache
@@ -141,7 +141,7 @@ teardown() {
   run ddev exec bash -c "cd /var/www/html/third && pnpm install"
   assert_success
 
-  run ddev exec bash -c "grep -r 'is-odd' /mnt/ddev-global-cache/pnpm 2>/dev/null | grep '2.0.0'"
+  run ddev exec bash -c "grep -R 'is-odd' /mnt/ddev-global-cache/pnpm 2>/dev/null | grep '2.0.0'"
   assert_success
 
   run ddev exec bash -c "node -e \"console.log(require('/var/www/html/third/node_modules/is-odd/package.json').version)\""

--- a/tests/testdata/frontend/package.json
+++ b/tests/testdata/frontend/package.json
@@ -9,7 +9,6 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.5.2",
   "dependencies": {
     "is-odd": "3.0.1"
   }

--- a/web-build/Dockerfile.pnpm
+++ b/web-build/Dockerfile.pnpm
@@ -4,8 +4,8 @@ RUN (command -v pnpm >/dev/null 2>&1 || npm install --global pnpm) && \
     PNPM_SCRIPT=$(printf '%s\n' \
         'export PNPM_HOME="/mnt/ddev-global-cache/pnpm"' \
         'case ":$PATH:" in' \
-        '    *":$PNPM_HOME:"*) ;;' \
-        '    *) PATH="$PNPM_HOME:$PATH" ;;' \
+        '    *":$PNPM_HOME/bin:"*) ;;' \
+        '    *) PATH="$PNPM_HOME/bin:$PATH" ;;' \
         'esac' \
         'export PATH') && \
     echo "$PNPM_SCRIPT" >> /etc/bash.bashrc && \


### PR DESCRIPTION
## The Issue

PNPM 11 has some changes https://pnpm.io/blog/releases/11.0

- https://github.com/pnpm/pnpm/pull/11038

https://github.com/ddev/ddev-pnpm/actions/runs/25546596230/job/75019556138

```
not ok 1 install from directory
# (from function `assert_success' in file /home/linuxbrew/.linuxbrew/lib/bats-assert/src/assert_success.bash, line 42,
#  from function `health_checks' in file tests/test.bats, line 48,
#  in test file tests/test.bats, line 84)
#   `health_checks' failed
#
# -- command failed --
# status : 1
# output (3 lines):
#   [ERROR] The configured global bin directory "/mnt/ddev-global-cache/pnpm/bin" is not in PATH
#   Run "pnpm setup" to update your shell configuration.
#   Failed to execute command `pnpm config get store-dir --global`: exit status 1
```

https://pnpm.io/blog/releases/11.0#isolated-global-virtual-store-global-installs

`pnpm link` has been tightened too: only relative or absolute paths are accepted, `--global` is removed (use `pnpm add -g .`), and `pnpm link` with no arguments is removed.

## How This PR Solves The Issue

- Updates `$PATH` to use `$PNPM_HOME/bin`
- Fixes `$PNPM_DIRECTORY` - it should always be relative to `$DDEV_APPROOT`, otherwise it's going to be run in the wrong place, because the `ddev pnpm` command has `## HostWorkingDir: true`

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/ddev/ddev-pnpm/tarball/refs/pull/13/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
