### PR TITLE
feat: support all Node.js versions, fixes #14

### DIFF
--- a/commands/web/pnpm
+++ b/commands/web/pnpm
@@ -8,10 +8,6 @@
 ## HostWorkingDir: true
 ## MutagenSync: true
 
-if [ "$(pnpm config get store-dir --global)" == "undefined" ]; then
-  pnpm config set store-dir "$PNPM_HOME" --global
-fi
-
 # If a $PNPM_DIRECTORY is set, run our PNPM commands in that directory
 if [ -n "$PNPM_DIRECTORY" ]; then
   mkdir -p "$DDEV_APPROOT/$PNPM_DIRECTORY"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -133,6 +133,10 @@ teardown() {
 @test "v20 Node.js" {
   set -eu -o pipefail
 
+  if [[ "$(ddev --version)" == "ddev version v1.25.2" ]]; then
+    skip "Node.js v20 requires ddev v1.25.3+"
+  fi
+
   ddev config --nodejs-version=20
   assert_success
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -44,7 +44,7 @@ health_checks() {
   run ddev pnpm --version
   assert_success
 
-  run ddev exec pnpm config get store-dir --global
+  run ddev pnpm store path
   assert_success
   assert_output --partial "/mnt/ddev-global-cache/pnpm"
 
@@ -97,9 +97,12 @@ teardown() {
 
 @test "use ENV to set working directory" {
   set -eu -o pipefail
+
   export HAS_PNPM_DIRECTORY=true
+
   # Create a frontend project
   cp -r "${DIR}/tests/testdata/frontend" "${TESTDIR}/frontend"
+
   # Set the PNPM_DIRECTORY to match our frontend project
   run ddev dotenv set .ddev/.env.web --pnpm-directory=frontend
   assert_success
@@ -113,38 +116,30 @@ teardown() {
   health_checks
 }
 
-@test "global cache is populated after install" {
+@test "latest Node.js" {
   set -eu -o pipefail
-  cp "${DIR}/tests/testdata/frontend/package.json" "${TESTDIR}/package.json"
+
+  ddev config --nodejs-version=latest
+  assert_success
 
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${DIR}"
   assert_success
   run ddev restart -y
   assert_success
+  health_checks
+}
 
-  # Verify is-odd@3.0.1 is stored in the global cache after installing
-  run ddev pnpm install
-  assert_success
-  run ddev exec bash -c "grep -R 'is-odd' /mnt/ddev-global-cache/pnpm 2>/dev/null | grep '3.0.1'"
-  assert_success
+@test "v20 Node.js" {
+  set -eu -o pipefail
 
-  # Install the same package version from a second directory and verify it is reused from cache
-  mkdir "${TESTDIR}/second"
-  cp "${TESTDIR}/package.json" "${TESTDIR}/second/package.json"
-  run ddev exec bash -c "cd /var/www/html/second && pnpm install 2>&1 | grep 'Progress:.*done' | grep 'reused [1-9]'"
+  ddev config --nodejs-version=20
   assert_success
 
-  # Install a different version of the same package and verify the correct version is installed
-  mkdir "${TESTDIR}/third"
-  printf '{"name":"third","version":"1.0.0","dependencies":{"is-odd":"2.0.0"}}' > "${TESTDIR}/third/package.json"
-  run ddev exec bash -c "cd /var/www/html/third && pnpm install"
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
   assert_success
-
-  run ddev exec bash -c "grep -R 'is-odd' /mnt/ddev-global-cache/pnpm 2>/dev/null | grep '2.0.0'"
+  run ddev restart -y
   assert_success
-
-  run ddev exec bash -c "node -e \"console.log(require('/var/www/html/third/node_modules/is-odd/package.json').version)\""
-  assert_success
-  assert_output "2.0.0"
+  health_checks
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -48,6 +48,23 @@ health_checks() {
   assert_success
   assert_output --partial "/mnt/ddev-global-cache/pnpm"
 
+  # Verify $PNPM_HOME is prepended to $PATH. The exact directory depends on the
+  # pnpm major version (see web-build/Dockerfile.pnpm): pnpm v11+ uses
+  # $PNPM_HOME/bin, older versions use $PNPM_HOME directly.
+  run ddev pnpm -v
+  assert_success
+
+  pnpm_version="${output#v}"
+  if [[ "${pnpm_version%%.*}" -ge 11 ]]; then
+    expected_path="/mnt/ddev-global-cache/pnpm/bin"
+  else
+    expected_path="/mnt/ddev-global-cache/pnpm"
+  fi
+
+  run ddev exec 'echo ":$PATH:"'
+  assert_success
+  assert_output --partial ":${expected_path}:"
+
   if [[ "${HAS_PNPM_DIRECTORY}" == "true" ]]; then
     run ddev pnpm test
     assert_success

--- a/web-build/Dockerfile.pnpm
+++ b/web-build/Dockerfile.pnpm
@@ -1,12 +1,49 @@
 #ddev-generated
 
-RUN (command -v pnpm >/dev/null 2>&1 || npm install --global pnpm) && \
-    PNPM_SCRIPT=$(printf '%s\n' \
-        'export PNPM_HOME="/mnt/ddev-global-cache/pnpm"' \
-        'case ":$PATH:" in' \
-        '    *":$PNPM_HOME/bin:"*) ;;' \
-        '    *) PATH="$PNPM_HOME/bin:$PATH" ;;' \
-        'esac' \
-        'export PATH') && \
-    echo "$PNPM_SCRIPT" >> /etc/bash.bashrc && \
-    echo "$PNPM_SCRIPT" >> /etc/bash.nointeractive.bashrc
+RUN <<EOF
+set -eu -o pipefail
+if ! command -v pnpm >/dev/null 2>&1; then
+    NODE_VERSION=$(node -v)
+    IFS=. read -r NODE_MAJOR NODE_MINOR _ <<< "${NODE_VERSION#v}"
+    if [ "$NODE_MAJOR" -gt 22 ] || { [ "$NODE_MAJOR" -eq 22 ] && [ "$NODE_MINOR" -ge 13 ]; }; then
+        PNPM_TAG="latest"
+    elif [ "$NODE_MAJOR" -gt 18 ] || { [ "$NODE_MAJOR" -eq 18 ] && [ "$NODE_MINOR" -ge 12 ]; }; then
+        PNPM_TAG="latest-10"
+    elif [ "$NODE_MAJOR" -gt 16 ] || { [ "$NODE_MAJOR" -eq 16 ] && [ "$NODE_MINOR" -ge 14 ]; }; then
+        PNPM_TAG="latest-8"
+    elif [ "$NODE_MAJOR" -gt 14 ] || { [ "$NODE_MAJOR" -eq 14 ] && [ "$NODE_MINOR" -ge 6 ]; }; then
+        PNPM_TAG="latest-7"
+    elif [ "$NODE_MAJOR" -gt 12 ] || { [ "$NODE_MAJOR" -eq 12 ] && [ "$NODE_MINOR" -ge 17 ]; }; then
+        PNPM_TAG="latest-6"
+    elif [ "$NODE_MAJOR" -gt 10 ] || { [ "$NODE_MAJOR" -eq 10 ] && [ "$NODE_MINOR" -ge 13 ]; }; then
+        PNPM_TAG="latest-5"
+    elif [ "$NODE_MAJOR" -gt 7 ] || { [ "$NODE_MAJOR" -eq 7 ] && [ "$NODE_MINOR" -ge 6 ]; }; then
+        PNPM_TAG="latest-3"
+    elif [ "$NODE_MAJOR" -ge 6 ]; then
+        PNPM_TAG="latest-2"
+    elif [ "$NODE_MAJOR" -ge 4 ]; then
+        PNPM_TAG="latest-1"
+    else
+        PNPM_TAG="latest"
+    fi
+    npm install -g pnpm@"$PNPM_TAG" -f
+fi
+PNPM_VERSION=$(pnpm -v)
+IFS=. read -r PNPM_MAJOR _ <<< "${PNPM_VERSION#v}"
+if [ "$PNPM_MAJOR" -ge 11 ]; then
+    PNPM_BIN=/bin
+else
+    PNPM_BIN=
+fi
+PNPM_SCRIPT=$(printf '%s\n' \
+    'export PNPM_HOME="/mnt/ddev-global-cache/pnpm"' \
+    'export pnpm_config_store_dir="$PNPM_HOME"' \
+    'export npm_config_store_dir="$PNPM_HOME"' \
+    'case ":$PATH:" in' \
+    '    *":$PNPM_HOME'"$PNPM_BIN"':"*) ;;' \
+    '    *) PATH="$PNPM_HOME'"$PNPM_BIN"':$PATH" ;;' \
+    'esac' \
+    'export PATH')
+echo "$PNPM_SCRIPT" >> /etc/bash.bashrc
+echo "$PNPM_SCRIPT" >> /etc/bash.nointeractive.bashrc
+EOF


### PR DESCRIPTION
## The Issue

- Fixes #14

Related:

- https://github.com/ddev/ddev/pull/8443

## How This PR Solves The Issue

- Conditionally installs the appropriate pnpm version (this works in [DDEV HEAD](https://docs.ddev.com/en/stable/developers/building-contributing/#testing-latest-commits-on-head) and will be available in DDEV v1.25.3)
- Adds `pnpm_config_store_dir` and `npm_config_store_dir` (different `pnpm` versions support different env variables)
- Adjusts PATH to support pnpm 11+ and previous versions
- Adds testing for the `latest` and `20` Node.js versions

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/ddev/ddev-pnpm/tarball/refs/pull/15/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
