### PR TITLE
test: add back the test for `pnpm install`

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -41,13 +41,6 @@ setup() {
 }
 
 health_checks() {
-  run ddev pnpm --version
-  assert_success
-
-  run ddev pnpm store path
-  assert_success
-  assert_output --partial "/mnt/ddev-global-cache/pnpm"
-
   # Verify $PNPM_HOME is prepended to $PATH. The exact directory depends on the
   # pnpm major version (see web-build/Dockerfile.pnpm): pnpm v11+ uses
   # $PNPM_HOME/bin, older versions use $PNPM_HOME directly.
@@ -65,6 +58,10 @@ health_checks() {
   assert_success
   assert_output --partial ":${expected_path}:"
 
+  run ddev pnpm store path
+  assert_success
+  assert_output --partial "/mnt/ddev-global-cache/pnpm"
+
   if [[ "${HAS_PNPM_DIRECTORY}" == "true" ]]; then
     run ddev pnpm test
     assert_success
@@ -74,6 +71,35 @@ health_checks() {
     assert_success
     assert_file_exist package.json
   fi
+
+  # Verify the global cache is populated after install and reused across directories.
+  # Install is-odd@3.0.1 and verify it is stored in the global cache.
+  mkdir "${TESTDIR}/cache-first"
+  cp "${DIR}/tests/testdata/frontend/package.json" "${TESTDIR}/cache-first/package.json"
+  run ddev exec bash -c "cd /var/www/html/cache-first && pnpm install"
+  assert_success
+  run ddev exec bash -c "grep -R 'is-odd' /mnt/ddev-global-cache/pnpm 2>/dev/null | grep '3.0.1'"
+  assert_success
+
+  # Install the same package version from a second directory and verify it is reused from cache
+  mkdir "${TESTDIR}/cache-second"
+  cp "${DIR}/tests/testdata/frontend/package.json" "${TESTDIR}/cache-second/package.json"
+  run ddev exec bash -c "cd /var/www/html/cache-second && pnpm install"
+  assert_success
+  run ddev exec bash -c "cd /var/www/html/cache-second && pnpm list 2>&1 | grep 'is-odd'"
+  assert_success
+  assert_output --partial "3.0.1"
+
+  # Install a different version of the same package and verify the correct version is installed
+  mkdir "${TESTDIR}/cache-third"
+  printf '{"name":"third","version":"1.0.0","dependencies":{"is-odd":"2.0.0"}}' > "${TESTDIR}/cache-third/package.json"
+  run ddev exec bash -c "cd /var/www/html/cache-third && pnpm install"
+  assert_success
+  run ddev exec bash -c "grep -R 'is-odd' /mnt/ddev-global-cache/pnpm 2>/dev/null | grep '2.0.0'"
+  assert_success
+  run ddev exec bash -c "cd /var/www/html/cache-third && pnpm list 2>&1 | grep 'is-odd'"
+  assert_success
+  assert_output --partial "2.0.0"
 
   run ddev pnpm link .
   assert_success
@@ -131,42 +157,6 @@ teardown() {
   run ddev restart -y
   assert_success
   health_checks
-}
-
-@test "global cache is populated after install" {
-  set -eu -o pipefail
-  cp "${DIR}/tests/testdata/frontend/package.json" "${TESTDIR}/package.json"
-
-  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
-  run ddev add-on get "${DIR}"
-  assert_success
-  run ddev restart -y
-  assert_success
-
-  # Verify is-odd@3.0.1 is stored in the global cache after installing
-  run ddev pnpm install
-  assert_success
-  run ddev exec bash -c "grep -R 'is-odd' /mnt/ddev-global-cache/pnpm 2>/dev/null | grep '3.0.1'"
-  assert_success
-
-  # Install the same package version from a second directory and verify it is reused from cache
-  mkdir "${TESTDIR}/second"
-  cp "${TESTDIR}/package.json" "${TESTDIR}/second/package.json"
-  run ddev exec bash -c "cd /var/www/html/second && pnpm install 2>&1 | grep 'Progress:.*done' | grep 'reused [1-9]'"
-  assert_success
-
-  # Install a different version of the same package and verify the correct version is installed
-  mkdir "${TESTDIR}/third"
-  printf '{"name":"third","version":"1.0.0","dependencies":{"is-odd":"2.0.0"}}' > "${TESTDIR}/third/package.json"
-  run ddev exec bash -c "cd /var/www/html/third && pnpm install"
-  assert_success
-
-  run ddev exec bash -c "grep -R 'is-odd' /mnt/ddev-global-cache/pnpm 2>/dev/null | grep '2.0.0'"
-  assert_success
-
-  run ddev exec bash -c "node -e \"console.log(require('/var/www/html/third/node_modules/is-odd/package.json').version)\""
-  assert_success
-  assert_output "2.0.0"
 }
 
 @test "latest Node.js" {

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -133,6 +133,42 @@ teardown() {
   health_checks
 }
 
+@test "global cache is populated after install" {
+  set -eu -o pipefail
+  cp "${DIR}/tests/testdata/frontend/package.json" "${TESTDIR}/package.json"
+
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+  run ddev restart -y
+  assert_success
+
+  # Verify is-odd@3.0.1 is stored in the global cache after installing
+  run ddev pnpm install
+  assert_success
+  run ddev exec bash -c "grep -R 'is-odd' /mnt/ddev-global-cache/pnpm 2>/dev/null | grep '3.0.1'"
+  assert_success
+
+  # Install the same package version from a second directory and verify it is reused from cache
+  mkdir "${TESTDIR}/second"
+  cp "${TESTDIR}/package.json" "${TESTDIR}/second/package.json"
+  run ddev exec bash -c "cd /var/www/html/second && pnpm install 2>&1 | grep 'Progress:.*done' | grep 'reused [1-9]'"
+  assert_success
+
+  # Install a different version of the same package and verify the correct version is installed
+  mkdir "${TESTDIR}/third"
+  printf '{"name":"third","version":"1.0.0","dependencies":{"is-odd":"2.0.0"}}' > "${TESTDIR}/third/package.json"
+  run ddev exec bash -c "cd /var/www/html/third && pnpm install"
+  assert_success
+
+  run ddev exec bash -c "grep -R 'is-odd' /mnt/ddev-global-cache/pnpm 2>/dev/null | grep '2.0.0'"
+  assert_success
+
+  run ddev exec bash -c "node -e \"console.log(require('/var/www/html/third/node_modules/is-odd/package.json').version)\""
+  assert_success
+  assert_output "2.0.0"
+}
+
 @test "latest Node.js" {
   set -eu -o pipefail
 


### PR DESCRIPTION
## The Issue

I thought this test wasn't needed, and removed it in:

- #15

But actually this is the only test that runs `pnpm install`, so it's important.

## How This PR Solves The Issue

Adds the test back, but runs it in `health_checks` instead.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-pnpm/tarball/refs/pull/16/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
